### PR TITLE
Adds auctions list to favourites page

### DIFF
--- a/components/LayoutMenu.js
+++ b/components/LayoutMenu.js
@@ -12,7 +12,8 @@ const links = [
   },
   {
     to: "/favourites",
-    name: "Favourites"
+    name: "Favourites",
+    authRequired: true
   },
   {
     to: "/my-auctions",

--- a/hooks/useSubscribeToWatchlist.js
+++ b/hooks/useSubscribeToWatchlist.js
@@ -1,0 +1,36 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useUser } from '@/contexts/UserContext'
+
+function useSubscribeToWatchlist ({ supabase }) {
+  const { user_id } = useUser()
+  const [watchlist, setWatchlist] = useState([])
+
+  const fetchWatchlist = useCallback(async() => {
+    const { data } = await supabase.from('watchlist').select('auction_id')
+    const watch = data.map(item => item.auction_id)
+    setWatchlist(watch)
+  }, [])
+
+  useEffect(() => {
+    fetchWatchlist()
+  }, [])
+
+  useEffect(() => {
+    const collection = `watchlist:user_id=eq.${user_id}`
+    const subscription = supabase
+      .from(collection)
+      .on('INSERT', fetchWatchlist)
+      .on('DELETE', fetchWatchlist)
+      .subscribe()
+
+    return () => {
+      supabase.removeSubscription(subscription)
+    }
+  }, [user_id])
+
+  return {
+    watchlist
+  }
+}
+
+export default useSubscribeToWatchlist

--- a/pages/discover.js
+++ b/pages/discover.js
@@ -1,4 +1,3 @@
-import { useRouter } from 'next/router'
 import { supabase } from '@/lib/initSupabase'
 import Head from 'next/head'
 import AuctionList from '../components/AuctionList'
@@ -7,8 +6,6 @@ import AuctionAPIService from '@/services/AuctionAPIService'
 const auctionAPIService = new AuctionAPIService(supabase)
 
 function Discover ({ auctions }) {
-  const router = useRouter()
-
   return (
     <>
       <Head>

--- a/pages/favourites.js
+++ b/pages/favourites.js
@@ -48,4 +48,6 @@ function Favourites() {
   )
 }
 
+Favourites.authRequired = true
+
 export default Favourites

--- a/pages/favourites.js
+++ b/pages/favourites.js
@@ -1,6 +1,36 @@
+import { useEffect, useState } from 'react'
+import { supabase } from '@/lib/initSupabase'
 import Head from 'next/head'
+import AuctionList from '../components/AuctionList'
+import useSubscribeToWatchlist from '@/hooks/useSubscribeToWatchlist'
 
 function Favourites() {
+  const [auctions, setAuctions] = useState([])
+  const [loading, setLoading] = useState(true)
+  const { watchlist } = useSubscribeToWatchlist({ supabase })
+
+  useEffect(async () => {
+    if (watchlist.length === 0) {
+      setAuctions([])
+      return
+    }
+
+    setLoading(true)
+    const { data } = await supabase.from('auctions').select('id, name, slug, auction_images(public_url)').in('id', watchlist)
+    setAuctions(data)
+    setLoading(false)
+  }, [watchlist])
+
+  let component = <AuctionList />
+
+  if (loading) {
+    component = <div>Loading...</div>
+  } else if (auctions.length) {
+    component = <AuctionList auctions={auctions} />
+  } else {
+    component = <p className="text-gray-700">You are not currently watching any Auctions</p>
+  }
+
   return (
     <>
       <Head>
@@ -11,6 +41,8 @@ function Favourites() {
         <h1 className="font-semibold text-2xl mb-4">
           Favourites
         </h1>
+
+        {component}
       </div>
     </>
   )

--- a/sql/2.create_bids.sql
+++ b/sql/2.create_bids.sql
@@ -19,3 +19,7 @@ create policy "Individuals can create bids." on bids for
 
 create policy "Bids are public." on bids for
     select using (true);
+
+-- Enable replication for realtime
+alter publication supabase_realtime add table bids;
+

--- a/sql/3.create_watchlist.sql
+++ b/sql/3.create_watchlist.sql
@@ -26,3 +26,7 @@ create policy "Users can delete their own watch."
   for delete using (
     auth.uid() = user_id
   );
+
+-- Enable replication for realtime
+-- Requires full as we want to listen for deletes too
+alter table watchlist replica identity full;


### PR DESCRIPTION
* Display a list of auctions being watched by the user to the Favourites page.
  * As this is user specific data we retrieve auction data on the client-side.
* Adds realtime updates to the favourites page
  * Changes to a users watchlist will trigger a subscription which will fetch data if the favourites page is currently open.
* Adds auth required for Favourites page
* Removes an unused router call from Discover page
